### PR TITLE
Add travis-ci files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+sudo: required
+language: python
+python:
+  - "3.6"
+
+services:
+  - docker
+
+addons:
+  apt:
+    packages:
+    - libxmlsec1-dev
+
+before_install:
+- docker build -t hubscrub .
+
+before_script:
+- docker run --rm -d -e GITHUB_API_TOKEN=test -e GITHUB_ORGANIZATION=mesosphere --name hubscrub hubscrub
+- sleep 30
+
+script:
+- docker logs hubscrub 2>&1 | grep "failed to check rate limit"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# hubscrub
+# hubscrub [![Build Status](https://travis-ci.org/sschneid/hubscrub.svg?branch=master)](https://travis-ci.org/sschneid/hubscrub)
 
 hubscrub is a whitehat security tool allowing organizations to monitor the public commits and gists of their members and alert when defined patterns are detected.
 


### PR DESCRIPTION
Add a first version of a travis ci build script that'll check that the Docker image can be build and container run, failing to connect to Github with the fake API token.
