### PR TITLE
Add /api/health endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,18 @@
 FROM python:3.6.1
 
-RUN apt-get update
-RUN apt-get install -y libxmlsec1-dev
-RUN apt-get install -y redis-server
-
-ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /bin/dumb-init
-
 WORKDIR /opt/hubscrub
 
+RUN apt-get update \
+    && apt-get install -y libxmlsec1-dev redis-server
+
+# Copy and install requirements.txt separately
+# for more efficient image build caching.
+COPY requirements.txt /opt/hubscrub/requirements.txt
+RUN pip3 install -r requirements.txt
+
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /bin/dumb-init
 COPY . /opt/hubscrub
-RUN pip3 install -r requirements.txt \
-    && chmod +x /opt/hubscrub/startup /bin/dumb-init
+RUN chmod +x /opt/hubscrub/startup /bin/dumb-init
 
 ENTRYPOINT [ "/bin/dumb-init", "--" ]
 CMD ["/opt/hubscrub/startup"]

--- a/hubscrub/__init__.py
+++ b/hubscrub/__init__.py
@@ -1,10 +1,15 @@
 from threading import Thread
+from time import time
 import logging
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 logger.propagate = False
 formatter = logging.Formatter('[%(asctime)s] %(message)s')
+
+# dict that gets rendered out at /api/health
+# fetch/store on global dicts is thread safe due to GIL
+health = {'startup': time()}
 
 fh = logging.FileHandler('/tmp/hubscrub.log', 'w')
 fh.setLevel(logging.DEBUG)

--- a/hubscrub/scan.py
+++ b/hubscrub/scan.py
@@ -3,7 +3,7 @@ import re
 from time import sleep, time
 from threading import Thread
 
-from hubscrub import app
+from hubscrub import app, health
 from hubscrub.http import authorized_request, authorized_request_following_links, authorized_request_raw
 from hubscrub.redis import init_redis_client
 from hubscrub.slack import slack_alert
@@ -214,6 +214,7 @@ def github_gist_scan(member, fingerprints):
 
 def github_scan():
     global redis_client
+    health['scan_start'] = time()
     try:
         redis_client.ping()
     except:
@@ -250,6 +251,7 @@ def github_scan():
 def periodic_scan():
     global redis_client
     while True:
+        health['scan_event_loop'] = time()
         try:
             redis_client.ping()
         except:

--- a/hubscrub/templates/vulnerabilities.html
+++ b/hubscrub/templates/vulnerabilities.html
@@ -8,7 +8,7 @@
         <th>member</th>
         <th>matched</th>
         <th>file</th>
-    </head>
+    </thead>
     <tbody>
     </tbody>
 </table>

--- a/hubscrub/views.py
+++ b/hubscrub/views.py
@@ -1,9 +1,10 @@
 from collections import deque
 from threading import Thread
 
+from time import time
 from flask import jsonify, render_template, request, send_file, session
 
-from hubscrub import app
+from hubscrub import app, health
 from hubscrub.redis import init_redis_client
 from hubscrub.scan import github_scan
 from hubscrub.slack import slack_approve
@@ -185,3 +186,8 @@ def api_vulnerability(vulnerability_id):
             return jsonify(vulnerability)
     else:
         return jsonify({'ok': False})
+
+
+@app.route('/api/health', methods=['GET'])
+def api_health():
+    return jsonify({'now': time(), **health})


### PR DESCRIPTION
Adds an /api/health endpoint that renders information about when individual parts of the software were last active:
```
{
  "now": 1498743264.9319148, 
  "scan_event_loop": 1498743226.2781615, 
  "scan_start": 1498743226.2787797, 
  "startup": 1498743226.1946108
}
```